### PR TITLE
docs: clarify Copy JSON behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Deploy to GitHub Pages](https://github.com/paraserv/debt_calc/actions/workflows/pages.yml/badge.svg)](https://github.com/paraserv/debt_calc/actions/workflows/pages.yml)
 [![Tests](https://github.com/paraserv/debt_calc/actions/workflows/tests.yml/badge.svg)](https://github.com/paraserv/debt_calc/actions/workflows/tests.yml)
 [![CodeQL](https://github.com/paraserv/debt_calc/actions/workflows/codeql.yml/badge.svg)](https://github.com/paraserv/debt_calc/actions/workflows/codeql.yml)
+
+> Copy JSON copies your configuration to the clipboard for pasting (e.g., into a text editor or chat). Use Save/Load Configuration to write/read a JSON file.
 [![GitHub Pages](https://img.shields.io/badge/Pages-live-2ea44f)](https://paraserv.github.io/debt_calc/)
 
 A single-file, client-side calculator to compare debt payoff strategies and generate payoff schedules. No backend required.


### PR DESCRIPTION
Clarifies that Copy JSON copies configuration to the clipboard; Save/Load deals with JSON files. This should help reduce confusion during export/import. Fixes #?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include a note on the “Copy JSON” feature, explaining how it copies the current configuration to the clipboard.
  * Clarified usage of “Save Configuration” and “Load Configuration” for writing/reading a JSON file.
  * Placed the new documentation immediately after the GitHub Actions badges.
  * No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->