### PR TITLE
docs: document local-only analytics toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ This repo uses GitHub Pages + Actions. On push to `main`, the site is deployed a
 
 ## License
 MIT — see `LICENSE`.
+
+## UI tips
+- Method cards show explanations on hover (0.5s delay).
+- Most buttons show a short tooltip on hover.
+- Press Esc to close modals; Enter confirms when available.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ MIT — see `LICENSE`.
 - Method cards show explanations on hover (0.5s delay).
 - Most buttons show a short tooltip on hover.
 - Press Esc to close modals; Enter confirms when available.
+
+## Analytics
+- Local-only analytics toggle records counts (no network).
+- Toggle button located in the header; state persists in your browser only.


### PR DESCRIPTION
Explains the header toggle and that analytics data never leaves the browser. No code changes.