### PR TITLE
docs: add README Showcase section (GIF placeholder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ MIT — see `LICENSE`.
 ## Analytics
 - Local-only analytics toggle records counts (no network).
 - Toggle button located in the header; state persists in your browser only.
+
+## Showcase
+![demo](https://user-images.githubusercontent.com/placeholder/animated-gif.gif)
+
+> Tip: Open Compare All Methods, then click a card to adopt that method.


### PR DESCRIPTION
Adds a Showcase section with a placeholder GIF; we can swap in a recorded demo to help with Stars. No code changes.