### PR TITLE
chore: refine .gitignore (build + cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@
 Thumbs.db
 .idea/
 .vscode/
+# Build artifacts
+/dist/
+/node_modules/
+
+# More local temp
+/tmp/
+*.cache
+


### PR DESCRIPTION
Adds common build/cache ignores and keeps local temp files out of git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings to exclude common build artifacts and temporary files. This helps keep the repository clean, reduces accidental commits, and improves developer workflows.
  * No user-facing behavior changes; the application’s functionality remains the same.
  * Benefits include smaller diffs, faster checkouts, and more consistent local environments across contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->