### PR TITLE
feat: extra payment focus, waterfall polish, Esc shortcut, What-If Scenario Planner

### DIFF
--- a/debt-calculator.html
+++ b/debt-calculator.html
@@ -1700,8 +1700,13 @@
             // Check if this payment is before start date
             updateExtraPayments();
             row.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            const amountInput = row.querySelector('input[type="number"]');
-            if (amountInput) amountInput.focus();
+            if (!copyFrom) {
+                const dateDisplay = row.querySelector('.date-display');
+                if (dateDisplay) dateDisplay.focus();
+            } else {
+                const amountInput = row.querySelector('input[type="number"]');
+                if (amountInput) amountInput.focus();
+            }
         }
         
         function formatMonthYear(dateStr) {

--- a/debt-calculator.html
+++ b/debt-calculator.html
@@ -1005,6 +1005,17 @@
         body.dark .payoff-collapse { background: #1f2937 !important; color: #9ca3af !important; }
         body.dark .schedule-preview { background: #0b1220; border: 1px solid #1f2937; }
         body.dark .payoff-collapse { background: #0f172a !important; color: #9ca3af !important; border: 1px solid #1f2937; }
+
+        /* Scenario Planner */
+        .scenario-planner-card { margin-bottom: 16px; }
+        .scenario-planner-header { display: flex; justify-content: space-between; align-items: center; cursor: pointer; user-select: none; }
+        .scenario-card { border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px 16px; margin-bottom: 12px; background: #f8fafc; }
+        .scenario-rule-row { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; flex-wrap: wrap; }
+        .scenario-rule-row input, .scenario-rule-row select { background: white; color: #1a202c; }
+        .scenario-results { padding: 8px 12px; border-radius: 6px; border: 1px solid #c6f6d5; background: #f0fff4; font-size: 13px; }
+        body.dark .scenario-card { background: #0f172a; border-color: #374151; }
+        body.dark .scenario-results { background: #0d2b1f; border-color: #22543d; }
+        body.dark .scenario-rule-row input, body.dark .scenario-rule-row select { background: #1f2937; color: #e5e7eb; border-color: #374151; }
     </style>
 </head>
 <body>
@@ -1136,6 +1147,20 @@
                 <button class="small has-tooltip" onclick="copyConfigurationJSON()" data-tooltip="Copy current configuration (debts, extra payments, method, totals, start date) to clipboard as JSON. Paste to a text editor or share; restore using Load Configuration (JSON file).">📋 Copy JSON</button>
             </div>
             <div class="debug-info" id="debugInfo" style="display: none;"></div>
+        </div>
+
+        <div class="card scenario-planner-card" id="scenarioPlannerSection">
+            <div class="scenario-planner-header" onclick="toggleScenarioPlanner()">
+                <h3 style="margin:0;">🔮 What-If Scenarios</h3>
+                <div style="display:flex; align-items:center; gap:10px;">
+                    <span style="font-size:13px; color:#718096;">Model extra payments without changing your plan</span>
+                    <span id="scenarioPlannerChevron" style="font-size:14px; color:#718096;">▼</span>
+                </div>
+            </div>
+            <div id="scenarioPlannerBody" style="display:none; margin-top:14px;">
+                <div id="scenariosList"></div>
+                <button class="small success" onclick="addScenario()" style="margin-top:4px;">+ Add Scenario</button>
+            </div>
         </div>
 
         <h2>📅 Payoff Schedule</h2>
@@ -2964,7 +2989,7 @@
             };
         }
 
-        function calculatePayoffSchedule(debtList = null, sortMethod = currentMethod) {
+        function calculatePayoffSchedule(debtList = null, sortMethod = currentMethod, scenarioPayments = []) {
             try {
                 let workingDebts = debtList ? JSON.parse(JSON.stringify(debtList)) : JSON.parse(JSON.stringify(debts));
                 
@@ -3019,7 +3044,9 @@
                     
                     // Find all extra payments for this specific month
                     const extraPaymentsThisMonth = extraPayments.filter(p => p.month === month);
-                    const extraThisMonth = extraPaymentsThisMonth.reduce((sum, p) => sum + p.amount, 0);
+                    const scenarioPaymentsThisMonth = scenarioPayments.filter(p => p.month === month);
+                    const extraThisMonth = extraPaymentsThisMonth.reduce((sum, p) => sum + p.amount, 0)
+                                        + scenarioPaymentsThisMonth.reduce((sum, p) => sum + p.amount, 0);
                     
                     // Total available extra = base extra + scheduled extra payments
                     let availableExtra = baseExtra + extraThisMonth;
@@ -3335,6 +3362,211 @@
             }
         }
 
+        // ====== What-If Scenario Planner ======
+        let scenarios = [];
+        let scenarioIdCounter = 0;
+        let scenarioPlannerOpen = false;
+
+        function toggleScenarioPlanner() {
+            scenarioPlannerOpen = !scenarioPlannerOpen;
+            document.getElementById('scenarioPlannerBody').style.display = scenarioPlannerOpen ? 'block' : 'none';
+            document.getElementById('scenarioPlannerChevron').textContent = scenarioPlannerOpen ? '▲' : '▼';
+        }
+
+        function addScenario() {
+            scenarioIdCounter++;
+            const letter = scenarioIdCounter <= 26
+                ? String.fromCharCode(64 + scenarioIdCounter)
+                : scenarioIdCounter;
+            scenarios.push({ id: scenarioIdCounter, name: 'Scenario ' + letter, rules: [] });
+            renderScenarios();
+        }
+
+        function removeScenario(id) {
+            scenarios = scenarios.filter(s => s.id !== id);
+            renderScenarios();
+        }
+
+        function addScenarioRule(scenarioId, type) {
+            const scenario = scenarios.find(s => s.id === scenarioId);
+            if (!scenario) return;
+            const startDate = document.getElementById('startDate').value || '';
+            scenario.rules.push({ id: Date.now(), type, amount: '', fromDate: startDate, toDate: '' });
+            renderScenarios();
+        }
+
+        function removeScenarioRule(scenarioId, ruleId) {
+            const scenario = scenarios.find(s => s.id === scenarioId);
+            if (!scenario) return;
+            scenario.rules = scenario.rules.filter(r => r.id !== ruleId);
+            renderScenarios();
+            updateAllScenarioResults();
+        }
+
+        function updateScenarioField(scenarioId, field, value) {
+            const scenario = scenarios.find(s => s.id === scenarioId);
+            if (scenario) scenario[field] = value;
+        }
+
+        function updateScenarioRule(scenarioId, ruleId, field, value) {
+            const scenario = scenarios.find(s => s.id === scenarioId);
+            if (!scenario) return;
+            const rule = scenario.rules.find(r => r.id === ruleId);
+            if (!rule) return;
+            rule[field] = value;
+            if (field === 'type') {
+                renderScenarios();
+            } else {
+                updateAllScenarioResults();
+            }
+        }
+
+        function dateToMonthOffset(dateStr) {
+            const startStr = document.getElementById('startDate').value;
+            if (!startStr || !dateStr) return null;
+            const [sy, sm] = startStr.split('-').map(Number);
+            const [dy, dm] = dateStr.split('-').map(Number);
+            const offset = (dy - sy) * 12 + (dm - sm) + 1;
+            return offset > 0 ? offset : null;
+        }
+
+        function expandRulesToPayments(rules, maxMonths = 600) {
+            const payments = [];
+            rules.forEach(rule => {
+                const amount = parseFloat(rule.amount);
+                if (!amount || amount <= 0) return;
+                if (rule.type === 'once') {
+                    const month = dateToMonthOffset(rule.fromDate);
+                    if (month) payments.push({ month, amount });
+                } else {
+                    const fromMonth = dateToMonthOffset(rule.fromDate) || 1;
+                    const toMonth = rule.toDate ? dateToMonthOffset(rule.toDate) : maxMonths;
+                    if (!toMonth || toMonth < fromMonth) return;
+                    for (let m = fromMonth; m <= toMonth; m++) {
+                        payments.push({ month: m, amount });
+                    }
+                }
+            });
+            return payments;
+        }
+
+        function computeScenarioResults(scenario) {
+            const payments = expandRulesToPayments(scenario.rules);
+            if (!payments.length) return null;
+            const baseline = calculatePayoffSchedule();
+            const withScenario = calculatePayoffSchedule(null, currentMethod, payments);
+            if (!baseline.length || !withScenario.length) return null;
+            const baseMonths = baseline.length;
+            const scenMonths = withScenario.length;
+            const baseInterest = baseline.reduce((sum, m) =>
+                sum + Object.values(m.interest || {}).reduce((s, v) => s + (v || 0), 0), 0);
+            const scenInterest = withScenario.reduce((sum, m) =>
+                sum + Object.values(m.interest || {}).reduce((s, v) => s + (v || 0), 0), 0);
+            return {
+                payoffDate: getPayoffDate(scenMonths),
+                basePayoffDate: getPayoffDate(baseMonths),
+                monthsSaved: baseMonths - scenMonths,
+                interestSaved: baseInterest - scenInterest
+            };
+        }
+
+        function updateAllScenarioResults() {
+            if (!scenarioPlannerOpen) return;
+            scenarios.forEach(scenario => {
+                const resultsEl = document.getElementById('scenario-results-' + scenario.id);
+                if (!resultsEl) return;
+                const startDate = document.getElementById('startDate').value;
+                if (!startDate) {
+                    resultsEl.innerHTML = '<span style="color:#718096;">Set a start date to see projections.</span>';
+                    return;
+                }
+                const hasAmounts = scenario.rules.some(r => parseFloat(r.amount) > 0);
+                if (!hasAmounts) {
+                    resultsEl.innerHTML = '<span style="color:#718096;">Add payment amounts to see projections.</span>';
+                    return;
+                }
+                const results = computeScenarioResults(scenario);
+                if (!results) {
+                    resultsEl.innerHTML = '<span style="color:#718096;">Unable to calculate — check debts and start date.</span>';
+                    return;
+                }
+                const mColor = results.monthsSaved > 0 ? '#38a169' : results.monthsSaved < 0 ? '#e53e3e' : '#718096';
+                const iColor = results.interestSaved > 0 ? '#38a169' : results.interestSaved < 0 ? '#e53e3e' : '#718096';
+                const mText = results.monthsSaved > 0 ? results.monthsSaved + ' months sooner'
+                            : results.monthsSaved < 0 ? Math.abs(results.monthsSaved) + ' months later'
+                            : 'same timeline';
+                resultsEl.innerHTML = `
+                    <div style="display:flex; gap:16px; flex-wrap:wrap; align-items:center;">
+                        <span>📅 <strong>${results.payoffDate}</strong> <span style="color:#718096; font-size:12px;">(vs. ${results.basePayoffDate})</span></span>
+                        <span style="color:${mColor};">⏱️ <strong>${mText}</strong></span>
+                        <span style="color:${iColor};">💰 saves <strong>${formatCurrency(results.interestSaved)}</strong> interest</span>
+                    </div>`;
+            });
+        }
+
+        function renderScenarios() {
+            const container = document.getElementById('scenariosList');
+            if (!container) return;
+            if (scenarios.length === 0) {
+                container.innerHTML = '<p style="color:#718096; font-size:13px; margin:0 0 8px;">No scenarios yet. Add one to model "what if" extra payments.</p>';
+                return;
+            }
+            container.innerHTML = scenarios.map(scenario => {
+                const rulesHTML = scenario.rules.map(rule => {
+                    const isRecurring = rule.type === 'recurring';
+                    const toField = isRecurring ? `
+                        <span style="font-size:12px; color:#718096;">to</span>
+                        <input type="month" value="${rule.toDate}"
+                            style="padding:4px 6px; border-radius:4px; border:1px solid #e2e8f0; font-size:12px;"
+                            oninput="updateScenarioRule(${scenario.id}, ${rule.id}, 'toDate', this.value)"
+                            placeholder="">
+                        <span style="font-size:11px; color:#a0aec0;">(blank = until payoff)</span>` : '';
+                    return `
+                        <div class="scenario-rule-row">
+                            <select onchange="updateScenarioRule(${scenario.id}, ${rule.id}, 'type', this.value)"
+                                style="padding:4px 6px; border-radius:4px; border:1px solid #e2e8f0; font-size:12px;">
+                                <option value="once" ${rule.type === 'once' ? 'selected' : ''}>One-time</option>
+                                <option value="recurring" ${rule.type === 'recurring' ? 'selected' : ''}>Recurring</option>
+                            </select>
+                            <span style="font-size:13px;">$</span>
+                            <input type="number" value="${rule.amount}" placeholder="Amount" step="50" min="0"
+                                style="width:90px; padding:4px 6px; border-radius:4px; border:1px solid #e2e8f0; font-size:13px;"
+                                oninput="updateScenarioRule(${scenario.id}, ${rule.id}, 'amount', this.value)">
+                            <span style="font-size:12px; color:#718096;">${isRecurring ? 'from' : 'in'}</span>
+                            <input type="month" value="${rule.fromDate}"
+                                style="padding:4px 6px; border-radius:4px; border:1px solid #e2e8f0; font-size:12px;"
+                                oninput="updateScenarioRule(${scenario.id}, ${rule.id}, 'fromDate', this.value)">
+                            ${toField}
+                            <button class="small danger" onclick="removeScenarioRule(${scenario.id}, ${rule.id})"
+                                style="padding:2px 8px; font-size:12px;">✕</button>
+                        </div>`;
+                }).join('');
+                return `
+                    <div class="scenario-card" id="scenario-card-${scenario.id}">
+                        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                            <input type="text" value="${escapeHtml(scenario.name)}"
+                                style="font-weight:bold; font-size:14px; border:none; border-bottom:1px dashed #cbd5e0;
+                                       background:transparent; color:inherit; padding:2px 4px; width:220px;"
+                                oninput="updateScenarioField(${scenario.id}, 'name', this.value)">
+                            <button class="small danger" onclick="removeScenario(${scenario.id})"
+                                style="padding:2px 10px;">✕ Remove</button>
+                        </div>
+                        <div>${rulesHTML || '<p style="color:#718096; font-size:12px; margin:0 0 6px;">No rules yet.</p>'}</div>
+                        <div style="display:flex; gap:8px; margin-top:8px;">
+                            <button class="small" onclick="addScenarioRule(${scenario.id}, 'once')"
+                                style="font-size:12px;">+ One-time</button>
+                            <button class="small" onclick="addScenarioRule(${scenario.id}, 'recurring')"
+                                style="font-size:12px;">+ Recurring</button>
+                        </div>
+                        <div class="scenario-results" id="scenario-results-${scenario.id}" style="margin-top:10px;">
+                            <span style="color:#718096;">Add payment amounts to see projections.</span>
+                        </div>
+                    </div>`;
+            }).join('');
+            updateAllScenarioResults();
+        }
+        // ====== End Scenario Planner ======
+
         function updateAmortizationTable(showFull = false) {
             try {
                 const schedule = calculatePayoffSchedule();
@@ -3503,7 +3735,8 @@
                 
                 updateSummary(schedule);
                 updatePayoffDates(schedule.debtPayoffMonths);
-                
+                updateAllScenarioResults();
+
                 // Auto-save state after updates
                 autoSave();
                 

--- a/debt-calculator.html
+++ b/debt-calculator.html
@@ -4264,6 +4264,10 @@
                     closeModal();
                 }
             });
+            // ESC to close comparison modal
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape' && modal.classList.contains('show')) closeModal();
+            });
             // Sticky info-tooltips: click to toggle, click-outside to close
             document.querySelectorAll('.info-tooltip').forEach(el => {
                 el.addEventListener('click', (ev) => {

--- a/debt-calculator.html
+++ b/debt-calculator.html
@@ -2196,22 +2196,36 @@
         let scheduleModalRow = null;
         
         function openScheduleModal(button) {
-            scheduleModalRow = button.parentElement;
+            scheduleModalRow = button.closest('.extra-payment-row');
             const modal = document.getElementById('scheduleModal');
             if (!modal) {
                 createScheduleModal();
             }
-            
+
             // Get current values from the row
-            const dateInput = scheduleModalRow.querySelector('input[type="hidden"]');
+            const dateInput = scheduleModalRow.querySelector('[id^="date-input-"]');
             const amountInput = scheduleModalRow.querySelector('input[type="number"]');
             const descInput = scheduleModalRow.querySelector('input[type="text"]');
-            
+
             // Set initial values in the modal (default to row date or global start date)
             const globalStart = document.getElementById('startDate').value || '';
-            document.getElementById('scheduleStartDate').value = (dateInput.value || globalStart);
+            const resolvedDate = dateInput.value || globalStart;
+            document.getElementById('scheduleStartDate').value = resolvedDate;
             document.getElementById('scheduleAmount').value = amountInput.value || '';
             document.getElementById('scheduleDescription').value = descInput.value || 'Quarterly bonus';
+
+            // Sync the visible date label and pre-render the calendar to the resolved date
+            const scheduleModal = document.getElementById('scheduleModal');
+            const displayEl = scheduleModal.querySelector('[id^="date-display-"]');
+            if (displayEl) {
+                displayEl.querySelector('span:first-child').textContent =
+                    resolvedDate ? formatMonthYear(resolvedDate) : 'Select Month';
+                const modalCalendarId = displayEl.id.replace('date-display-', '');
+                if (resolvedDate) {
+                    const [y, m] = resolvedDate.split('-');
+                    renderModalCalendar(modalCalendarId, new Date(parseInt(y), parseInt(m) - 1));
+                }
+            }
             
             // Set defaults to quarterly and until debt free
             document.getElementById('scheduleFrequency').value = 'quarterly';

--- a/debt-calculator.html
+++ b/debt-calculator.html
@@ -3763,9 +3763,9 @@
                         if (monthData.phase && monthData.phase !== 'Complete') {
                             const phaseRow = body.insertRow();
                             phaseRow.innerHTML = `
-                                <td colspan="5" style="background: ${getThemeColor('#e6f2ff', '#1a202c')}; 
+                                <td colspan="5" style="background: ${getThemeColor('#e6f2ff', '#1a202c')};
                                          color: ${getThemeColor('#2563eb', '#60a5fa')}; padding: 12px; text-align: center; font-weight: bold;">
-                                    🚀 Begin: ${monthData.phase}${getPhaseThresholdText(monthData.phase)}
+                                    🚀 ${monthData.phase}${getPhaseThresholdText(monthData.phase)}
                                 </td>
                             `;
                             phaseStartMonth = index;
@@ -3850,19 +3850,28 @@
                             totalExtraForMonth += card.extraPayment;
                         });
                         
+                        const monthDate = getPayoffDate(monthData.month - 1);
+                        const phaseProgress = monthData.phaseProgress || 0;
                         row.innerHTML = `
-                            <td><strong>${monthData.month}</strong></td>
+                            <td>
+                                <strong>${monthData.month}</strong>
+                                <div style="font-size: 11px; color: ${getThemeColor('#718096', '#a0aec0')};">${monthDate}</div>
+                            </td>
                             <td>${cardsHTML}</td>
                             <td>${paymentsHTML}</td>
                             <td>
-                                <span style="color: ${getThemeColor('#718096', '#a0aec0')};">${formatCurrency(totalPayments - totalExtraForMonth)}</span> + 
+                                <span style="color: ${getThemeColor('#718096', '#a0aec0')};">${formatCurrency(totalPayments - totalExtraForMonth)}</span> +
                                 <span style="color: ${getThemeColor('#667eea', '#818cf8')}; font-weight: bold;">${formatCurrency(totalExtraForMonth)}</span>
                                 = <strong>${formatCurrency(totalPayments)}</strong>
                             </td>
                             <td style="font-size: 12px;">
                                 <div>Util: <span style="color: ${overallUtil > 30 ? getThemeColor('#ed8936', '#f59e0b') : getThemeColor('#38a169', '#10b981')};">${overallUtil.toFixed(1)}%</span></div>
-                                <div style="color: ${getThemeColor('#718096', '#a0aec0')};">Phase: ${monthData.phaseProgress || 0}%</div>
-                                <div style="color: ${getThemeColor('#667eea', '#9f7aea')};">Month ${monthData.month}/${schedule.length}</div>
+                                <div style="margin-top: 4px;">
+                                    <div style="font-size: 10px; color: ${getThemeColor('#718096', '#a0aec0')}; margin-bottom: 2px;">Phase ${phaseProgress}%</div>
+                                    <div style="background: ${getThemeColor('#e2e8f0', '#374151')}; border-radius: 3px; height: 6px; width: 80px;">
+                                        <div style="background: ${getThemeColor('#667eea', '#818cf8')}; border-radius: 3px; height: 6px; width: ${phaseProgress}%;"></div>
+                                    </div>
+                                </div>
                             </td>
                         `;
                     } else if (monthData.month === 1 || (monthData.month % 12) === 1) {
@@ -3889,7 +3898,7 @@
                     .reduce((sum, b) => sum + (b || 0), 0);
                 
                 summaryRow.innerHTML = `
-                    <td colspan="5" style="background: #1a202c; color: #68d391; padding: 15px; text-align: center; font-weight: bold;">
+                    <td colspan="5" style="background: ${getThemeColor('#e6fffa', '#0d2b1f')}; color: ${getThemeColor('#22543d', '#68d391')}; padding: 15px; text-align: center; font-weight: bold; border: 1px solid ${getThemeColor('#38a169', '#22543d')};">
                         🎉 All Debts Paid Off! Total time: ${Math.floor(totalMonths / 12)}y ${totalMonths % 12}m
                     </td>
                 `;


### PR DESCRIPTION
## Summary
- fix: focus date picker (not amount) when adding a new extra payment row
- improve: Simplified Waterfall View — calendar dates, phase progress bars, cleaner phase headers, light-mode final row fix
- fix: Esc key now closes the Compare All Methods modal
- feat: What-If Scenario Planner — model one-time and recurring extra payment scenarios with live payoff/interest projections, multiple named scenarios side by side

## Test plan
- [ ] Add extra payment row → cursor lands on date picker
- [ ] Select Credit Score method → Show Simplified Waterfall View → verify dates, progress bars, final row in light + dark mode
- [ ] Open Compare All Methods modal → press Esc → closes
- [ ] Open What-If Scenarios, add a scenario with one-time and recurring rules → results update live
- [ ] `node tests.js && node run-tests.js && node validate-calculations.js` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * What-If Scenario Planner: Create and compare multiple debt payoff strategies with custom rules. View projected payoff dates, months saved, and interest savings for each scenario.
  * Payoff date displays now include full calendar dates in addition to month information across relevant tables.

* **UI/UX Enhancements**
  * Escape key closes the comparison modal for better keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->